### PR TITLE
OK - Added build status badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# Arbor for Android
-[![Build Status](https://travis-ci.org/ToastedSnackBar/arbor-android.svg?branch=master)](https://travis-ci.org/ToastedSnackBar/arbor-android)
+# Arbor for Android [![Build Status](https://travis-ci.org/ToastedSnackBar/arbor-android.svg?branch=master)](https://travis-ci.org/ToastedSnackBar/arbor-android)
 
 ## Description
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # Arbor for Android
+[![Build Status](https://travis-ci.org/ToastedSnackBar/arbor-android.svg?branch=master)](https://travis-ci.org/ToastedSnackBar/arbor-android)
+
+## Description
+
+A free and open source GitHub client. Powered by GitHub API v3.
+


### PR DESCRIPTION
* Build status badge ([![Build Status](https://travis-ci.org/ToastedSnackBar/arbor-android.svg?branch=master)](https://travis-ci.org/ToastedSnackBar/arbor-android)) now shows in `README.md`.