### PR TITLE
OK - Fix Butterknife breaking CI (tsk tsk)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -143,7 +143,7 @@ task jacocoTestReport(type: JacocoReport) {
     }
 
     def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*',
-                      '**/*Test*.*', 'android/**/*.*']
+                      '**/*Test*.*', 'android/**/*.*', '**/*$$*']
     def debugTree = fileTree(dir: "${buildDir}/intermediates/classes/debug", excludes: fileFilter)
     def mainSrc = "${projectDir}/src/main/java"
 


### PR DESCRIPTION
So apparently Butterknife adds an anonymous class (`ViewBinder`) into whatever class you use Butterknife in. Exclude these things from `jacocoTestReport`